### PR TITLE
assert and json dumps

### DIFF
--- a/backend/tests/blockchain/test_block.py
+++ b/backend/tests/blockchain/test_block.py
@@ -20,7 +20,7 @@ def test_genesis():
 
     assert isinstance(genesis, Block)
     for key, value in GENESIS_DATA.items():
-        getattr(genesis, key) == value
+       assert getattr(genesis, key) == value
 
 def test_quickly_mined_block():
     last_block = Block.mine_block(Block.genesis(), 'foo')

--- a/backend/util/crypto_hash.py
+++ b/backend/util/crypto_hash.py
@@ -5,8 +5,9 @@ def crypto_hash(*args):
     """
     Return a sha-256 hash of the given arguments.
     """
-    stringified_args = sorted(map(lambda data: json.dumps(data), args))
-    joined_data = ''.join(stringified_args)
+    # stringified_args = sorted(map(lambda data: json.dumps(data), args))
+    stringified_args=map(dumps(data),args)
+    joined_data = '^'.join(stringified_args)
 
     return hashlib.sha256(joined_data.encode('utf-8')).hexdigest()
 


### PR DESCRIPTION
1. in for loop you did't added assert statement by which comparison happen
2. json dumps will work even if w don't use lambda function
3. there is no need to sort args as 1,two,[3] must not be equal to two,[3],1
4. if we use empty character and join args we will get same hash if we use different args with same set of args example : 1,2,3 and 3,2,1 